### PR TITLE
Open new tab from "Report Issues" & start game with no players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 npm-debug.log
 test/unit/coverage
 .idea
+index.sublime-workspace

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -9,7 +9,7 @@
         <button class="btn btn-primary" v-on:click="showCredits">
         Credits
       </button>
-        <a class="btn btn-primary" href="https://github.com/sscullen/program-wars/issues/new">
+        <a class="btn btn-primary" href="https://github.com/sscullen/program-wars/issues/new" target="_blank">
         Report Issue
       </a>
       </div>

--- a/src/components/SettingsComponent.vue
+++ b/src/components/SettingsComponent.vue
@@ -9,7 +9,7 @@
           </div>
           <div class="modal-body flex-container">
             <div id="addPlayer">
-              <input type="text" placeholder="Add a player..." autofocus v-model="newPlayer" v-on:keyup.enter="submit">
+              <input type="text" placeholder="Add a player..." v-model="newPlayer" v-on:keyup.enter="submit" autofocus>
               <button type="button" class="btn btn-primary" v-on:click="submit">Add Player</button>
             </div>
             <div id="players">
@@ -31,7 +31,7 @@
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-primary" @click="submitPlayers" data-dismiss="modal">Start New Game</button>
+            <button type="button" class="btn btn-primary" @click="submitPlayers" data-dismiss="modal" :disabled="noPlayers">Start New Game</button>
           </div>
         </div>
       </div>
@@ -60,14 +60,16 @@
         localPlayers: [],
         newPlayer: '',
         gameStart: false,
-        selected: '10'
+        selected: '10',
+        noPlayers: true
       }
     },
     methods: {
       submit(e) {
         console.log(this.newPlayer)
         if(this.newPlayer.length > 0 && this.localPlayers.indexOf(this.newPlayer) < 0) {
-          this.localPlayers.push(this.newPlayer)
+          this.localPlayers.push(this.newPlayer);
+          this.noPlayers = false;
         }
 
         this.newPlayer = ""


### PR DESCRIPTION
I have added a target for the href link to GitHub for the "Report Issues" button to open in a new tab when clicked. 

I have also added a conditional disable to the "start new game" button to prevent the game from starting with no players.