### PR TITLE
Added a tips box explaining the different cards when clicked

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="card" :class="cardCss" class="panel panel-default" v-on:click="cardClicked ($event)" @click.stop draggable="true" @dragstart="cardDragged">
+  <div id="card" :class="cardCss" class="panel panel-default" @click="cardClicked ($event)" @click.stop draggable="true" @dragstart="cardDragged">
       <div class="panel-body flex-container">
         <div :class="typeCss">{{ cardType }}</div>
         <div :class="valueCss">{{ cardValue }}</div>
@@ -16,7 +16,6 @@ export default {
   props: ['cardData', 'inStack'],
   data () {
     return {
-      msg: 'Welcome to Your Vue.js App',
       valueCss: 'value',
       typeCss: 'type'
     }
@@ -100,20 +99,19 @@ export default {
 
 
     background-color: #fff;
-    min-width: 100px;
+    min-width: 90px;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -khtml-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-    min-height: 110px;
-    border: 0px solid #000000;
-
+    min-height: 120px;
+    border: 0px solid #000;
+    border-radius: 10px;
     padding: 10px 0px 10px 0px;
-
     margin: 0px 0px 0px 0px;
-}
+    }
 
 .flex-container {
   flex-direction:column;

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -225,8 +225,6 @@ export default {
             return 'Group Card'; break;
 
           default :
-//            this.tipsInfoText = 'Tips will be displayed here';
-//            return 'No Card Selected'; break;
             var fact = this.setFact();
             this.tipsInfoText = fact;
             return 'Did you know?';
@@ -237,8 +235,9 @@ export default {
       return this.facts[num];
     },
     deselectAll () {
-      document.removeEventListener('click', this.hide)
-      bus.$emit('cardDeselected')
+      document.removeEventListener('click', this.hide);
+      this.tipsCardSelected = this.setTipBox('default');
+      bus.$emit('cardDeselected');
       this.$store.commit('setStackSelectedBoolean', {payload: undefined})
 
       this.$store.commit('setActiveCardUndefined')
@@ -269,7 +268,6 @@ export default {
     }
   },
   created: function () {
-
     bus.$on('activeCardAddedToStack', (cardId) => {
       // a card was selected
       console.log('active card successfully added to stack, deslect and remove from hand')

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -59,7 +59,13 @@ export default {
       modalText: "",
       modalCards: [],
       tipsCardSelected:'Did you know?',
-      tipsInfoText: ''
+      tipsInfoText: '',
+      facts: [
+        'The first high-level programming language was FORTRAN. invented in 1954 by IBM’s John Backus.',
+        'The first computer programmer was a woman',
+        'A \"Hello, World!\" program is often the first program written when learning a new programming language',
+        'Counting starts at 0, not 1'
+      ]
     }
   },
   computed: {
@@ -227,20 +233,8 @@ export default {
         }
     },
     setFact() {
-      var num = Math.floor(Math.random() * 4) + 1;
-      console.log('num is: ' + num);
-      switch(num) {
-        case 1:
-          return 'The first high-level programming language was FORTRAN. invented in 1954 by IBM’s John Backus.'; break;
-        case 2:
-          return 'The first computer programmer was a woman'; break;
-        case 3:
-          return 'A \"Hello, World!\" program is often the first program written when learning a new programming language'; break;
-        case 4:
-          return 'Counting starts at 0, not 1'; break;
-        default:
-          return 'Default fun fact';
-      }
+      var num = Math.floor(Math.random() * this.facts.length);
+      return this.facts[num];
     },
     deselectAll () {
       document.removeEventListener('click', this.hide)

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -59,7 +59,7 @@ export default {
       modalText: "",
       modalCards: [],
       tipsCardSelected:'Did you know?',
-      tipsInfoText: '',
+      tipsInfoText: 'There are many different programming languages, C++, Java, Javascript, Python... just to name a few',
       facts: [
         'The first high-level programming language was FORTRAN. invented in 1954 by IBM’s John Backus.',
         'The first computer programmer was a woman',

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -5,7 +5,12 @@
 
       <h4 class="playerName"><b>{{ currentPlayerName }}</b>, It's Your Turn!</h4>
       <div id="flexcontainer">
-
+        <div id="tipBox" class="container" style="max-width: 350px; height: 280px" :cardClicked="tipsCardSelected">
+          <h5>{{ tipsCardSelected }}</h5>
+          <div class="panel panel-default">
+            <div class="panel-body">{{ tipsInfoText }}</div>
+          </div>
+        </div>
         <div id="cards">
 
           <ul id="example-1">
@@ -47,13 +52,14 @@ export default {
   name: 'PlayerInfoPanel',
   data () {
     return {
-      msg: 'Welcome to Your Vue.js App',
       title: 'Player Info Panel',
       idCounter: 6,
       showDiscardedCards: false,
       modalId: "discardCards",
       modalText: "",
-      modalCards: []
+      modalCards: [],
+      tipsCardSelected:'Did you know?',
+      tipsInfoText: ''
     }
   },
   computed: {
@@ -148,7 +154,7 @@ export default {
     },
     endTurn() {
       bus.$emit('checkWin')
-
+      this.tipsCardSelected = this.setTipBox('default');
       this.$store.commit('setHasPlayed', {hasPlayed:false})
 
       this.$store.commit('endTurn', this.$store.getters.maxplayers)
@@ -157,7 +163,7 @@ export default {
     cardClicked (c) {
       // alert('cardId of clicked card is ' + cardId)
       console.log(c.id)
-
+      this.tipsCardSelected = this.setTipBox(c);
       let prevActive = this.$store.getters.getActiveCard
 
       this.$store.commit('selectCard', c)
@@ -170,6 +176,71 @@ export default {
 
 
       setTimeout(() => document.addEventListener('click', this.deselectAll), 0)
+    },
+    setTipBox(c) {
+        switch(c.type) {
+          case 'I' :
+            this.tipsInfoText = 'Instruction cards are the basis of any program, ' +
+              'and are thus the basic card that any player will start a “stack” ' +
+              '(i.e. Instruction cards with modifiers placed on them) with.';
+            return 'Instruction Card'; break;
+          case 'R' :
+            this.tipsInfoText = 'Repetition cards are used to emulate the action of a loop, ' +
+              'repeating an instruction a number of times. ' +
+              'Repetition cards need an instruction card as a base before they can be played on a playfield. ' +
+              'Once played on an instruction, ' +
+              'a Repetition card multiplies the value of the underlying Instruction card by the value printed ' +
+              'on the Repetition card.';
+            return 'Repetition card'; break;
+
+          case 'V':
+            this.tipsInfoText = 'Variable cards are used in conjunction with Repetition X cards. ' +
+              'The value of the Variable card is then applied to the Repetition X card, ' +
+              'which specifies the value of X. ' +
+              'The value of X then becomes the multiplier for the underlying Instruction card.';
+            return 'Variable Card'; break;
+
+          case 'H':
+            this.tipsInfoText = 'Hack cards are a special card that players are allotted at the ' +
+              'beginning of the game. The Hack card can be played by a player on their turn with ' +
+              'the purpose of removing cards from an opposing players’ playfield. ' +
+              'When a Hack card is played, players specify a target for the Hack card, ' +
+              'and that card is discarded. If there are any modifier cards on top of the targeted card, ' +
+              'those cards are discarded from play as well. All cards are targetable by a ' +
+              'Hack card with the exception of Group cards.';
+            return 'Hack Card'; break;
+
+          case 'G' :
+            this.tipsInfoText = 'Group cards are used to emulate the notion of a function, ' +
+              'essentially aggregating a set of instructions together into one unit. ' +
+              'Group cards are played on one or more stacks of cards. ' +
+              'In order to play a Group card on one or more stacks, ' +
+              'the total point value of each of the stacks must be equal to the value of the Group card.';
+            return 'Group Card'; break;
+
+          default :
+//            this.tipsInfoText = 'Tips will be displayed here';
+//            return 'No Card Selected'; break;
+            var fact = this.setFact();
+            this.tipsInfoText = fact;
+            return 'Did you know?';
+        }
+    },
+    setFact() {
+      var num = Math.floor(Math.random() * 4) + 1;
+      console.log('num is: ' + num);
+      switch(num) {
+        case 1:
+          return 'The first high-level programming language was FORTRAN. invented in 1954 by IBM’s John Backus.'; break;
+        case 2:
+          return 'The first computer programmer was a woman'; break;
+        case 3:
+          return 'A \"Hello, World!\" program is often the first program written when learning a new programming language'; break;
+        case 4:
+          return 'Counting starts at 0, not 1'; break;
+        default:
+          return 'Default fun fact';
+      }
     },
     deselectAll () {
       document.removeEventListener('click', this.hide)
@@ -266,6 +337,11 @@ export default {
   #player-info-panel {
     background-color: #ccc;
 }
+
+  #tipBox {
+    position: relative;
+    top: -40px;
+  }
 
   h1, h2, h3, h4, h5 {
     margin-top: 0px;

--- a/src/components/Playfield.vue
+++ b/src/components/Playfield.vue
@@ -19,7 +19,6 @@ export default {
   props: ['trueFalse', 'playerId'],
   data () {
     return {
-      msg: 'Welcome to Your Vue.js App',
       title: 'Playfield',
       numberOfStacks: 1,
       test: 'default'

--- a/src/components/Stack.vue
+++ b/src/components/Stack.vue
@@ -35,7 +35,6 @@ export default {
   props: ['playfieldBoolean', 'stackId', 'playerId'],
   data () {
     return {
-      msg: 'Welcome to Your Vue.js App',
       title: 'Stack',
       id: this.stackId,
       dataContent: "hello",


### PR DESCRIPTION
This feature is a new suggestion, it adds an info box next to the players hand. The info displays information about the card clicked giving the player a better understanding of what each card does. When no cards are selected I added a simple random fact generator, this information can be changed to anything relevant. Note that the text is more or less placeholder and can/should be modified/reviewed, the card info has been taken out directly from the group report. 